### PR TITLE
fix: never apply server.address/proxy.url from DB overrides at startup

### DIFF
--- a/cmd/iulita/main.go
+++ b/cmd/iulita/main.go
@@ -311,16 +311,12 @@ func main() {
 		}
 	}
 
-	// Re-apply DB overrides that are NOT hot-reloaded so dashboard-saved values
-	// take effect on this start. These are consumed directly from cfg (restart-only
-	// keys; the self-improvement gate), so unlike the loop above they must be
-	// applied unconditionally — including over non-empty compiled defaults.
-	if v, ok := cfgStore.GetEffective("proxy.url"); ok && v != "" {
-		cfg.Proxy.URL = v
-	}
-	if v, ok := cfgStore.GetEffective("server.address"); ok && v != "" {
-		cfg.Server.Address = v
-	}
+	// Re-apply DB overrides for non-hot-reloaded, app-level keys so dashboard-saved
+	// values take effect on this start. NOTE: deployment-owned infrastructure keys
+	// (server.address, proxy.url) are deliberately NOT re-applied from the DB — in a
+	// container the listen address/port and proxy belong to the deployment
+	// (containerPort, probes, env). A stale dashboard override must never move the
+	// server off the port the readiness/liveness probes expect.
 	if v, ok := cfgStore.GetEffective("skills.selfimprove.enabled"); ok {
 		cfg.Skills.SelfImprove.Enabled = strings.EqualFold(v, "true")
 	}


### PR DESCRIPTION
v0.31.1 re-applied restart-only DB overrides into cfg at startup so dashboard saves would take effect. For the self-improvement gate that is correct, but for deployment-owned infrastructure keys it is dangerous: a stale dashboard override of server.address (e.g. ":9090" saved while testing the config editor) moved the dashboard off the container port (:8080) that the k8s readiness/liveness probes target, causing connection-refused and a crash loop.

In a container the listen address/port and proxy belong to the deployment (containerPort, probes, env), not the app DB. Drop the proxy.url/server.address startup re-injection; keep only the self-improvement keys. The stale override becomes harmless (ignored), so the app binds the compiled/deployment default and the probes pass again.